### PR TITLE
The previous version used random sampling with duplicates

### DIFF
--- a/skfeature/function/similarity_based/reliefF.py
+++ b/skfeature/function/similarity_based/reliefF.py
@@ -1,5 +1,4 @@
 import numpy as np
-from random import randrange
 from sklearn.metrics.pairwise import pairwise_distances
 
 
@@ -41,8 +40,7 @@ def reliefF(X, y, **kwargs):
     score = np.zeros(n_features)
 
     # the number of sampled instances is equal to the number of total instances
-    for iter in range(n_samples):
-        idx = randrange(0, n_samples, 1)
+    for idx in range(n_samples):
         near_hit = []
         near_miss = dict()
 


### PR DESCRIPTION
I am using this library for my research with my mentor (Marko Robnik - the actual co author of Relief :)) and we noticed some instability with the algorithm. 

I then checked the code and it seemed like the algorithm was using random sampling with duplicates (when iterating over n_samples anyway...).

So I made a change and a pull request. The detailed explanation is below:

The previous version used random sampling with duplicate examples from the dataset.
The algorithm idea states that it should use random sampling of m examples without duplicates because duplicates cause unstable results where the effect of some examples will be aplified and
some will be ignored.
Whereas since the current code set m to n_samples (all examples), there's really no point in random sampling since you use all examples anyway. The order of sample processing doesn't matter either, so
I removed all this random sampling bit and just let it loop through
results.

In future I can modify the algorithm to use another argument m and use a
random subset of examples properly (like stated in the article), but for now I did it like this.

The algorithm is stable now. It might be cook to have this sorted on master as well since some people are using it and it doesn't perform too well now.

I can also do the m samples subset modification later on. Let me know.


Sincerely, Tadej Magajna