### PR TITLE
Fixed bugs in FCBF.py and mutual_information.py

### DIFF
--- a/skfeature/function/information_theoretical_based/FCBF.py
+++ b/skfeature/function/information_theoretical_based/FCBF.py
@@ -36,7 +36,7 @@ def fcbf(X, y, **kwargs):
         delta = 0
 
     # t1[:,0] stores index of features, t1[:,1] stores symmetrical uncertainty of features
-    t1 = np.zeros((n_features, 2))
+    t1 = np.zeros((n_features, 2), dtypes='object')
     for i in range(n_features):
         f = X[:, i]
         t1[i, 0] = i
@@ -63,6 +63,6 @@ def fcbf(X, y, **kwargs):
                 idx = np.transpose(idx)
                 # delete the feature by using the mask
                 s_list = s_list[idx]
-                length = len(s_list)/2
+                length = len(s_list)//2
                 s_list = s_list.reshape((length, 2))
     return np.array(F, dtype=int), np.array(SU)

--- a/skfeature/utility/mutual_information.py
+++ b/skfeature/utility/mutual_information.py
@@ -1,4 +1,4 @@
-import entropy_estimators as ee
+import skfeature.utility.entropy_estimators as ee
 
 
 def information_gain(f1, f2):


### PR DESCRIPTION
FCBF.py
line 39: add dtypes='object' to allow both int and float data types in np.array t1.
lien 66: replace / with // to make variable length an integer.

mutual_information.py:
#21 