### PR TITLE
Fixing "dtypes" parameter of np.zeros in FCBF.py

### DIFF
--- a/skfeature/function/information_theoretical_based/FCBF.py
+++ b/skfeature/function/information_theoretical_based/FCBF.py
@@ -36,7 +36,7 @@ def fcbf(X, y, **kwargs):
         delta = 0
 
     # t1[:,0] stores index of features, t1[:,1] stores symmetrical uncertainty of features
-    t1 = np.zeros((n_features, 2), dtypes='object')
+    t1 = np.zeros((n_features, 2), dtype='object')
     for i in range(n_features):
         f = X[:, i]
         t1[i, 0] = i


### PR DESCRIPTION
Hello,

I was using the FCBF method in my research project at school and it triggered an error due to a typo in the "dtype" parameter of np.zeros.

The "dtypes" parameter of np.zeros in FCBF.py should instead be "dtype" according to https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.zeros.html

Sincerely,

Henrique Silveira