### PR TITLE
Fixing a 'division by zero' error in skfeature/utility/mutual_information.py

### DIFF
--- a/skfeature/utility/mutual_information.py
+++ b/skfeature/utility/mutual_information.py
@@ -61,6 +61,9 @@ def su_calculation(f1, f2):
     # calculate entropy of f2, t3 = H(f2)
     t3 = ee.entropyd(f2)
     # su(f1,f2) = 2*t1/(t2+t3)
-    su = 2.0*t1/(t2+t3)
+    if (t2+t3 == 0): # avoid a division by zero error when t2+t3=0 
+        su = 0
+    else:
+        su = 2.0*t1/(t2+t3)
 
     return su

--- a/skfeature/utility/mutual_information.py
+++ b/skfeature/utility/mutual_information.py
@@ -61,9 +61,6 @@ def su_calculation(f1, f2):
     # calculate entropy of f2, t3 = H(f2)
     t3 = ee.entropyd(f2)
     # su(f1,f2) = 2*t1/(t2+t3)
-    if (t2+t3 == 0): # avoid a division by zero error when t2+t3=0 
-        su = 0
-    else:
-        su = 2.0*t1/(t2+t3)
+    su = 2.0*t1/(t2+t3)
 
     return su


### PR DESCRIPTION
Hello,

I was using the CFS method in my thesis project at college and it triggered a"division by zero' error when calculating the symmetrical uncertainty.  Given the formula: su(f1,f2) = 2*IG(f1,f2)/(H(f1)+H(f2)), when H(f1)+H(f2) is equal to zero, it triggers a "division by zero" error.

Best regards,
Jose D.